### PR TITLE
Adjust middleman dependency to >= 3.0.0

### DIFF
--- a/font-awesome-middleman.gemspec
+++ b/font-awesome-middleman.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency(%q<middleman>,           ["~> 3.0.0"])
+  gem.add_runtime_dependency(%q<middleman>,           [">= 3.0.0"])
 
   gem.add_development_dependency(%q<bundler>,         ["~> 1.1"])
   gem.add_development_dependency(%q<rspec>,           ["~> 2.6.0"])


### PR DESCRIPTION
I tried using this gem with Middleman 3.1.3 and had dependency issues as Middleman was pessimistically version constrained to 3.0.x. Changing to an optimistic version constraint fixed the issue.
